### PR TITLE
fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.terraform
+.terraform.lock.hcl


### PR DESCRIPTION
`terraform init`を手元で実施したときに出来るファイルを除外。