### PR TITLE
change version

### DIFF
--- a/environments/develop/compute-scaleout/main.tf
+++ b/environments/develop/compute-scaleout/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 1.00"
   required_providers {
     oci = {
       version = ">= 3.27"


### PR DESCRIPTION
Oracle-Tagが見えないエラーを解消

```
Error: 400-RelatedResourceNotAuthorizedOrNotFound
Provider version: 4.57.0, released on 2021-12-15. This provider is 2 version(s) old.
Service: Core Instance
Error Message: The following tag namespaces / keys are not authorized or not found: 'oracle-tags'
OPC request ID: 270fa91a38320ffcfc3281b1414a5291/8BA9A1DB63A5F7642EED509012775BF5/E52352D3271ACAF53F57084EDE1E4E80
Suggestion: Please retry or contact support for help with service: Core Instance
  on ../../../modules/compute-instance/main.tf line 35, in resource "oci_core_instance" "this" 
  35: resource "oci_core_instance" "this" {

```