### PR TITLE
Topic/change nsg

### DIFF
--- a/environments/develop/network/terraform.tfvars
+++ b/environments/develop/network/terraform.tfvars
@@ -53,6 +53,17 @@ network_security_groups = {
     dest_port    = [{min: 22, max: 22}]
     stateless    = false
     icmp_options = null
+  },{
+    direction    = "INGRESS"
+    src_type     = "NSG"
+    src          = "public"
+    protocol     = "ALL"
+    src_port     = null
+    dest_type    = null
+    dest         = null
+    dest_port    = null
+    stateless    = false
+    icmp_options = null
   }],
   applications = [{
     direction    = "INGRESS"

--- a/modules/iam-group/templates/administrator_policy.tftpl
+++ b/modules/iam-group/templates/administrator_policy.tftpl
@@ -1,4 +1,4 @@
-Allow group ${group_name} to read tag-namespaces in tenancy
-Allow group ${group_name} to read tagdefinitions in tenancy
-Allow group ${group_name} to read tag-defaults in tenancy
+Allow group ${group_name} to manage tag-namespaces in tenancy
+Allow group ${group_name} to manage tagdefinitions in tenancy
+Allow group ${group_name} to manage tag-defaults in tenancy
 Allow group ${group_name} to manage all-resources in compartment ${compartment_name}


### PR DESCRIPTION
Computeを再作成する際にOracle-Tagsが無いというエラーになることを避けるためにmanageの権限にする。